### PR TITLE
Update Decrypt.php

### DIFF
--- a/Decrypt.php
+++ b/Decrypt.php
@@ -110,7 +110,7 @@ class Decrypt extends AbstractLoader
 
         $jwt = new JWT();
         $jwt->header->replace($jwe->getSharedProtectedHeader());
-        $jwt->claims->replace(JsonConverter::decode($jwe->getPayload()));
+        $jwt->claims->replace((array)JsonConverter::decode((string)$jwe->getPayload()));
 
         $claimChecker = new Checker\ClaimCheckerManager($this->claimCheckers);
         $claimChecker->check($jwt->claims->all());


### PR DESCRIPTION
If the payload is null, then JsonConverter::decode fail with an incorrect argument error (waiting for string, null sent).
By forcing cast , it allow process to keep going. 
I hesitated to throw an exception in that case, but i thought that a token without payload is possible after all.

Please do not submit any Pull Requests here. It will be automatically closed.

You should submit it here: https://github.com/web-token/jwt-framework/pulls
